### PR TITLE
Adds command to pull latest docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ To install dependencies:
   ```
 
 Alternatively, use the docker image [`ppasupat/phrasenode`](https://hub.docker.com/r/ppasupat/phrasenode/)
+For latest image: `docker pull ppasupat/phrasenode:1.06`
 
 ## Quick start
 


### PR DESCRIPTION
when i used `docker pull ppasupat/phrasenode` it says manifest for `:latest` tag could not be found 